### PR TITLE
Add default Xauthority

### DIFF
--- a/xcb/xml/auth.scm
+++ b/xcb/xml/auth.scm
@@ -35,7 +35,9 @@
      a record of type `xcb-connection', which is used for further
      interaction with the X server."
   (define (xcb-get-auths)
-    (define port (open-file (getenv "XAUTHORITY") "rb"))
+    (define port (open-file (or (getenv "XAUTHORITY")
+                                (format #f "~a/.Xauthority" (getenv "HOME")))
+                            "rb"))
     (define* (read-block)
       (define size
         (bytevector-u16-ref (get-bytevector-n port 2) 0 (endianness big)))


### PR DESCRIPTION
I have tried guile-wm and got an error.  It happened because i don't have XAUTHORITY environment variable.  I think it would be good to fall back to a default `~/.Xauthority` file in such cases.  (I'm new to guile and am not sure if there is a better way to expand file name).

And thank you for the GREAT work on guile-wm and guile-xcb.
