### PR TITLE
Match on empty xauth-display

### DIFF
--- a/xcb/xml/auth.scm
+++ b/xcb/xml/auth.scm
@@ -79,7 +79,7 @@
   (or (string=
        (assq-ref (parse-display-name display-string) 'display)
        xauth-display)
-      (string-null? display-string)))
+      (string-null? xauth-display)))
 
 (define (xcb-match-auth auths display-name hostname)
   (define (auth-match? auth)

--- a/xcb/xml/auth.scm
+++ b/xcb/xml/auth.scm
@@ -75,10 +75,11 @@
     `((display . ,(match:substring m 1))
       (screen . ,(match:substring m 2))))
 
-  (define (display-match? xauth-display display-string)
-    (string=
-     (assq-ref (parse-display-name display-string) 'display)
-     xauth-display))
+(define (display-match? xauth-display display-string)
+  (or (string=
+       (assq-ref (parse-display-name display-string) 'display)
+       xauth-display)
+      (string-null? display-string)))
 
 (define (xcb-match-auth auths display-name hostname)
   (define (auth-match? auth)

--- a/xcb/xml/auth.scm
+++ b/xcb/xml/auth.scm
@@ -76,10 +76,10 @@
       (screen . ,(match:substring m 2))))
 
 (define (display-match? xauth-display display-string)
-  (or (string=
+  (or (string-null? xauth-display)
+      (string=
        (assq-ref (parse-display-name display-string) 'display)
-       xauth-display)
-      (string-null? xauth-display)))
+       xauth-display)))
 
 (define (xcb-match-auth auths display-name hostname)
   (define (auth-match? auth)


### PR DESCRIPTION
`(xcb-connect!)` fails for me because the display string is empty.
I'm assuming that means any display name is OK, since running `xauth extract` with any display name seems to match it.
